### PR TITLE
3.5.3 Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4h/angular",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Angular services and interfaces for the D4H API.",
   "homepage": "https://d4htechnologies.com/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4h/angular",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Angular services and interfaces for the D4H API.",
   "homepage": "https://d4htechnologies.com/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4h/angular",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Angular services and interfaces for the D4H API.",
   "homepage": "https://d4htechnologies.com/",
   "repository": {

--- a/src/lib/client-permissions.module.ts
+++ b/src/lib/client-permissions.module.ts
@@ -7,13 +7,13 @@ import {
 } from '@angular/core';
 
 import { CLIENT_PERMISSIONS } from './providers/permissions.provider';
-import { inspections, repairs } from './permissions';
+import { equipment, inspections, repairs } from './permissions';
 
 @NgModule({
   providers: [
     {
       provide: CLIENT_PERMISSIONS,
-      useValue: { inspections, repairs },
+      useValue: { equipment, inspections, repairs },
       multi: true
     }
   ]

--- a/src/lib/factories/cost.factory.ts
+++ b/src/lib/factories/cost.factory.ts
@@ -1,0 +1,17 @@
+import deepmerge from 'deepmerge';
+import faker from 'faker';
+import { Currency, CurrencyCost, SymbolCost } from '../../lib/models';
+
+export function CurrencyCost(attributes: Partial<CurrencyCost> = {}): CurrencyCost {
+  return deepmerge<CurrencyCost>({
+    currency: faker.finance.currencySymbol() as Currency,
+    value: faker.random.number()
+  }, attributes);
+}
+
+export function SymbolCost(attributes: Partial<SymbolCost> = {}): SymbolCost {
+  return deepmerge<SymbolCost>({
+    symbol: faker.finance.currencySymbol() as Currency,
+    value: faker.random.number()
+  }, attributes);
+}

--- a/src/lib/factories/equipment.factory.ts
+++ b/src/lib/factories/equipment.factory.ts
@@ -3,23 +3,17 @@ import faker from 'faker';
 
 import { Brand } from './brand.factory';
 import { Category } from './category.factory';
+import { CurrencyCost } from './cost.factory';
 import { Location } from './location.factory';
 import { Model } from './model.factory';
 import { sample, sequence } from '../tools';
 
 import {
-  Currency,
   Equipment,
-  EquipmentCost,
   EquipmentStatus,
   EquipmentType,
   Weight
 } from '../../lib/models';
-
-const cost = ({
-  currency = faker.finance.currencySymbol() as Currency,
-  value = faker.random.number()
-} = {}) => ({ currency, value });
 
 const weight = ({
   units = 'kg' as Weight,
@@ -45,9 +39,9 @@ export function Equipment(attributes: Partial<Equipment> = {}): Equipment {
     // ref: string;
 
     barcode: faker.random.uuid(),
-    cost_per_distance: cost(),
-    cost_per_hour: cost(),
-    cost_per_use: cost(),
+    cost_per_distance: CurrencyCost(),
+    cost_per_hour: CurrencyCost(),
+    cost_per_use: CurrencyCost(),
     critical_alert: critical,
     custom_fields: [],
     date_expires: faker.date.future().toISOString(),
@@ -64,11 +58,11 @@ export function Equipment(attributes: Partial<Equipment> = {}): Equipment {
     is_monitor: monitor,
     notes: faker.lorem.paragraph(),
     quantity: faker.random.number({ min: 9, max: 15 }),
-    replacement_cost: cost(),
+    replacement_cost: CurrencyCost(),
     serial: faker.random.uuid(),
     team_id: sequence('equipment.team_id'),
     title: faker.commerce.productName(),
-    total_replacement_cost: cost(),
+    total_replacement_cost: CurrencyCost(),
     total_weight: weight(),
     type: sample<EquipmentType>(EquipmentType),
     weight: weight(),

--- a/src/lib/factories/equipment.factory.ts
+++ b/src/lib/factories/equipment.factory.ts
@@ -12,13 +12,19 @@ import {
   Equipment,
   EquipmentCost,
   EquipmentStatus,
-  EquipmentType
+  EquipmentType,
+  Weight
 } from '../../lib/models';
 
 const cost = ({
   currency = faker.finance.currencySymbol() as Currency,
   value = faker.random.number()
 } = {}) => ({ currency, value });
+
+const weight = ({
+  units = 'kg' as Weight,
+  value = faker.random.number()
+} = {}) => ({ units, value });
 
 export function Equipment(attributes: Partial<Equipment> = {}): Equipment {
   const brand = Brand();
@@ -30,10 +36,6 @@ export function Equipment(attributes: Partial<Equipment> = {}): Equipment {
   const monitor = faker.random.boolean();
 
   return deepmerge<Equipment>({
-    // date_expires: Date;
-    // date_last_status_change: Date;
-    // date_retired: Date;
-    // date_warranty: Date;
     // is_all_child_op: boolean;
     // minutes_use: number;
     // odometer_reading: number;
@@ -41,8 +43,6 @@ export function Equipment(attributes: Partial<Equipment> = {}): Equipment {
     // odometer_reading_total: number;
     // odometer_reading_total_allowed: number;
     // ref: string;
-    // serial: string;
-    // total_weight: Weight;
 
     barcode: faker.random.uuid(),
     cost_per_distance: cost(),
@@ -50,11 +50,14 @@ export function Equipment(attributes: Partial<Equipment> = {}): Equipment {
     cost_per_use: cost(),
     critical_alert: critical,
     custom_fields: [],
+    date_expires: faker.date.future().toISOString(),
     date_firstuse: faker.date.past().toISOString(),
     date_last_moved: faker.date.past().toISOString(),
     date_last_status_change: faker.date.past().toISOString(),
     date_manufactured: faker.date.past().toISOString(),
     date_purchased: faker.date.past().toISOString(),
+    date_retired: faker.date.future().toISOString(),
+    date_warranty: faker.date.future().toISOString(),
     expire_alert: monitor,
     id,
     is_critical: critical,
@@ -62,10 +65,13 @@ export function Equipment(attributes: Partial<Equipment> = {}): Equipment {
     notes: faker.lorem.paragraph(),
     quantity: faker.random.number({ min: 9, max: 15 }),
     replacement_cost: cost(),
+    serial: faker.random.uuid(),
     team_id: sequence('equipment.team_id'),
     title: faker.commerce.productName(),
     total_replacement_cost: cost(),
+    total_weight: weight(),
     type: sample<EquipmentType>(EquipmentType),
+    weight: weight(),
 
     brand: {
       id: brand.id,

--- a/src/lib/factories/factory.tool.ts
+++ b/src/lib/factories/factory.tool.ts
@@ -5,6 +5,7 @@ import { Attendance } from './attendance.factory';
 import { Brand } from './brand.factory';
 import { Category } from './category.factory';
 import { Config } from './config.factory';
+import { CurrencyCost, SymbolCost } from './cost.factory';
 import { CustomField } from './custom-field.factory';
 import { Duty } from './duty.factory';
 import { EmergencyContact } from './emergency-contact.factory';
@@ -89,6 +90,7 @@ Factory.add({
   Brand,
   Category,
   Config,
+  CurrencyCost,
   CustomField,
   Duty,
   EmergencyContact,
@@ -111,6 +113,7 @@ Factory.add({
   Result,
   Role,
   StatusLabel,
+  SymbolCost,
   Team,
   Username
 });

--- a/src/lib/factories/repair.factory.ts
+++ b/src/lib/factories/repair.factory.ts
@@ -3,21 +3,9 @@ import faker from 'faker';
 
 import { Equipment } from './equipment.factory';
 import { Member } from './member.factory';
+import { MembershipType, Repair, RepairCause, RepairStatus } from '../../lib/models';
+import { SymbolCost } from './cost.factory';
 import { sample, sequence } from '../tools';
-
-import {
-  Currency,
-  MembershipType,
-  Repair,
-  RepairCause,
-  RepairStatus
-} from '../../lib/models';
-
-
-const cost = ({
-  symbol = faker.finance.currencySymbol() as Currency,
-  value = faker.random.number()
-} = {}) => ({ symbol, value });
 
 export function Repair(attributes: Partial<Repair> = {}): Repair {
   const activityId = sequence('repair.activity_id');
@@ -38,7 +26,7 @@ export function Repair(attributes: Partial<Repair> = {}): Repair {
     fund_id: sequence('repair.fund_id'),
     id: sequence('repair.id'),
     repair_activity_id: activityId,
-    repair_cost: cost(),
+    repair_cost: SymbolCost(),
     team_id: sequence('repair.team_id'),
     title: faker.lorem.sentence(),
 

--- a/src/lib/factories/role.factory.ts
+++ b/src/lib/factories/role.factory.ts
@@ -1,19 +1,15 @@
 import deepmerge from 'deepmerge';
 import faker from 'faker';
 
-import { Currency, Role } from '../../lib/models';
+import { CurrencyCost } from './cost.factory';
+import {  Role } from '../../lib/models';
 import { sequence } from '../tools';
-
-const cost = ({
-  currency = faker.finance.currencySymbol() as Currency,
-  value = faker.random.number()
-} = {}) => ({ currency, value });
 
 export function Role(attributes: Partial<Role> = {}): Role {
   return deepmerge<Role>({
     bundle: faker.name.jobType(),
-    cost_per_hour: cost(),
-    cost_per_use: cost(),
+    cost_per_hour: CurrencyCost(),
+    cost_per_use: CurrencyCost(),
     id: sequence('role.id'),
     organisation_id: null,
     title: faker.name.jobTitle(),

--- a/src/lib/models/cost.model.ts
+++ b/src/lib/models/cost.model.ts
@@ -1,0 +1,20 @@
+import { Currency } from './units.model';
+
+/**
+ * Costing
+ * =============================================================================
+ * Multiple models have costing information. Some use key currency, others key
+ * symbol.
+ *
+ * @see https://github.com/D4H/decisions-project/issues/3922
+ */
+
+export interface CurrencyCost {
+  currency: Currency;
+  value: number;
+}
+
+export interface SymbolCost {
+  symbol: Currency;
+  value: number;
+}

--- a/src/lib/models/equipment.model.ts
+++ b/src/lib/models/equipment.model.ts
@@ -1,12 +1,7 @@
-import { Currency } from './units.model';
+import { CurrencyCost } from './cost.model';
 import { CustomField } from './custom-field.model';
 import { IsoDate } from './iso-date.model';
 import { Weight } from './units.model';
-
-export interface EquipmentCost {
-  currency: Currency;
-  value: number;
-}
 
 export enum EquipmentStatus {
   Inactive = 0,
@@ -25,9 +20,9 @@ export enum EquipmentType {
 
 export interface Equipment {
   barcode: string;
-  cost_per_distance?: EquipmentCost;
-  cost_per_hour?: EquipmentCost;
-  cost_per_use?: EquipmentCost;
+  cost_per_distance?: CurrencyCost;
+  cost_per_hour?: CurrencyCost;
+  cost_per_use?: CurrencyCost;
   critical_alert: boolean;
   custom_fields?: Array<CustomField>;
   date_expires: IsoDate;
@@ -52,11 +47,11 @@ export interface Equipment {
   odometer_reading_total_allowed: number;
   quantity: number;
   ref: string;
-  replacement_cost: EquipmentCost;
+  replacement_cost: CurrencyCost;
   serial: string;
   team_id: number;
   title: string;
-  total_replacement_cost: EquipmentCost;
+  total_replacement_cost: CurrencyCost;
   type: EquipmentType;
   urls?: object;
 

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -3,6 +3,7 @@ export * from './activity.model';
 export * from './attendance.model';
 export * from './brand.model';
 export * from './category.model';
+export * from './cost.model';
 export * from './custom-field.model';
 export * from './duty.model';
 export * from './equipment.model';

--- a/src/lib/models/repair.model.ts
+++ b/src/lib/models/repair.model.ts
@@ -1,12 +1,7 @@
-import { Currency } from './units.model';
 import { EquipmentStatus, EquipmentType } from './equipment.model';
 import { IsoDate } from './iso-date.model';
 import { MembershipType } from './membership.model';
-
-/**
- * Repair Cause
- * =============================================================================
- */
+import { SymbolCost } from './cost.model';
 
 export enum RepairCause {
   Unknown = 0,
@@ -16,24 +11,14 @@ export enum RepairCause {
   Maintenance = 4
 }
 
-/**
- * Repair Status
- * =============================================================================
- */
-
 export enum RepairStatus {
   Completed = 0,
   InProgress = 1,
   NotStarted = 8
 }
 
-/**
- * Repair
- * =============================================================================
- */
-
 export interface Repair {
-  date_completed: IsoDate;
+  date_completed?: IsoDate;
   date_created: IsoDate;
   date_due: IsoDate;
   description: string;
@@ -44,6 +29,7 @@ export interface Repair {
   fund_id: number;
   id: number;
   repair_activity_id?: number;
+  repair_cost: SymbolCost;
   team_id: number;
   title: string;
 
@@ -74,11 +60,6 @@ export interface Repair {
   repair_cause: {
     id: RepairCause;
     label: string;
-  };
-
-  repair_cost: {
-    symbol: Currency;
-    value: number;
   };
 
   status: {

--- a/src/lib/models/role.model.ts
+++ b/src/lib/models/role.model.ts
@@ -1,4 +1,4 @@
-import { Currency } from './units.model';
+import { CurrencyCost } from './cost.model';
 import { XOR } from 'ts-xor';
 
 export type RoleInheritedEntity = XOR<
@@ -8,16 +8,8 @@ export type RoleInheritedEntity = XOR<
 
 export type Role = {
   bundle?: string;
+  cost_per_hour?: CurrencyCost;
+  cost_per_use?: CurrencyCost;
   id: number;
   title: string;
-
-  cost_per_hour?: {
-    currency: Currency;
-    value: number;
-  };
-
-  cost_per_use?: {
-    currency: Currency;
-    value: number;
-  };
 } & RoleInheritedEntity;

--- a/src/lib/permissions/equipment.permissions.ts
+++ b/src/lib/permissions/equipment.permissions.ts
@@ -1,0 +1,50 @@
+import { Member, Permission, Equipment } from '../models';
+import { Operation } from '../providers';
+
+/**
+ * Equipment Operation Permissions
+ * =============================================================================
+ * Operation.Read:
+ *
+ *  - Anyone can read, no further check required.
+ *
+ * Opperation.Update:
+ *
+ * All equipment update operations will fail if the equipment is pending
+ * transfer to another team, repesented as equipment.pending. This object
+ * attribute is only present on such equipment.
+ *
+ *  - equipment.pending === false OR:
+ *  - permission.name === Permission.Editor
+ *  - permission.name === Permission.Owner
+ *  - permission.gear === true
+ *
+ * @see https://github.com/D4H/decisions-project/issues/3905
+ */
+
+export function equipment(
+  member: Member,
+  operation: Operation = Operation.Read,
+  gear?: Equipment
+): boolean {
+  switch (operation) {
+    case Operation.Read: {
+      return Boolean(member);
+    }
+
+    case Operation.Update: {
+      if (gear && gear.pending) {
+        return false;
+      } else {
+        return (
+          [Permission.Editor, Permission.Owner].includes(member.permission.name)
+          || member.permission.gear
+        );
+      }
+    }
+
+    default: {
+      return false;
+    }
+  }
+}

--- a/src/lib/permissions/index.ts
+++ b/src/lib/permissions/index.ts
@@ -1,2 +1,3 @@
+export * from './equipment.permissions';
 export * from './inspection.permissions';
 export * from './repair.permissions';

--- a/src/lib/permissions/inspection.permissions.ts
+++ b/src/lib/permissions/inspection.permissions.ts
@@ -28,11 +28,11 @@ export function inspections(
     }
 
     case Operation.Update: {
-      return Boolean(inspection) && (
+      return (
         [Permission.Editor, Permission.Owner].includes(member.permission.name)
         || member.permission.gear
         || member.permission.gear_basic
-        || inspection.member_id === member.id
+        || Boolean(inspection) && inspection.member_id === member.id
       );
     }
 

--- a/src/lib/permissions/repair.permissions.ts
+++ b/src/lib/permissions/repair.permissions.ts
@@ -48,12 +48,12 @@ export function repairs(
     }
 
     case Operation.Update: {
-      return Boolean(repair) && (
+      return (
         [Permission.Editor, Permission.Owner].includes(member.permission.name)
         || member.permission.gear
         || member.permission.gear_basic
-        || repair.added_by.id === member.id
-        || repair.assigned_to.id === member.id
+        || Boolean(repair) && repair.added_by.id === member.id
+        || Boolean(repair) && repair.assigned_to.id === member.id
       );
     }
 

--- a/src/lib/providers/config.provider.ts
+++ b/src/lib/providers/config.provider.ts
@@ -39,7 +39,7 @@ export interface ConfigProvider {
  */
 
 export const CLIENT_NAME = 'D4H API CLIENT';
-export const CLIENT_VERSION = '3.5.0';
+export const CLIENT_VERSION = '3.5.1';
 
 export const CLIENT_CONFIG = new InjectionToken<ConfigProvider>(
   'CLIENT_CONFIGURATION'

--- a/src/lib/providers/config.provider.ts
+++ b/src/lib/providers/config.provider.ts
@@ -39,7 +39,7 @@ export interface ConfigProvider {
  */
 
 export const CLIENT_NAME = 'D4H API CLIENT';
-export const CLIENT_VERSION = '3.5.1';
+export const CLIENT_VERSION = '3.5.2';
 
 export const CLIENT_CONFIG = new InjectionToken<ConfigProvider>(
   'CLIENT_CONFIGURATION'

--- a/src/lib/tools/can.tool.ts
+++ b/src/lib/tools/can.tool.ts
@@ -57,11 +57,11 @@ export class Can {
     return this.action(member, type, Operation.Read, record);
   }
 
-  update<T>(member: Member, type: string, record: T): boolean {
+  update<T>(member: Member, type: string, record?: T): boolean {
     return this.action(member, type, Operation.Update, record);
   }
 
-  destroy<T>(member: Member, type: string, record: T): boolean {
+  destroy<T>(member: Member, type: string, record?: T): boolean {
     return this.action(member, type, Operation.Destroy, record);
   }
 }

--- a/src/lib/tools/index.ts
+++ b/src/lib/tools/index.ts
@@ -1,5 +1,5 @@
 export * from './api-url.tool';
+export * from './can.tool';
 export * from './datelike.tool';
-export * from './permissions.tool';
 export * from './sample.tool';
 export * from './sequence.tool';

--- a/src/spec/permissions/equipment.permissions.spec.ts
+++ b/src/spec/permissions/equipment.permissions.spec.ts
@@ -1,0 +1,92 @@
+import { Factory } from '../../lib/factories';
+import { Member, Permission, Equipment } from '../../lib/models';
+import { Operation } from '../../lib/providers';
+import { equipment } from '../../lib/permissions/equipment.permissions';
+
+describe('Equipment Permissions', () => {
+  let gear: Equipment;
+  let member;
+
+  beforeEach(() => {
+    member = {
+      id: 15,
+
+      permission: {
+        gear: false,
+        gear_basic: false,
+        name: Permission.None
+      }
+    } as Member;
+
+    gear = Factory.build('Equipment');
+  });
+
+  it('should be a function', () => {
+    expect(typeof equipment).toBe('function');
+    expect(equipment.length).toBe(1);
+  });
+
+  describe('Operation.Create', () => {
+    it('should always be false', () => {
+      member.permission.name = Permission.Editor;
+      expect(equipment(null, Operation.Create)).toBe(false);
+      expect(equipment(member, Operation.Create, null)).toBe(false);
+      expect(equipment(member, Operation.Create, gear)).toBe(false);
+    });
+  });
+
+  describe('Operation.Read', () => {
+    it('should be false without a member', () => {
+      expect(equipment(null)).toBe(false);
+      expect(equipment(null, Operation.Read, null)).toBe(false);
+    });
+
+    it('should always be true', () => {
+      expect(equipment(member)).toBe(true);
+      expect(equipment(member, Operation.Read, null)).toBe(true);
+      expect(equipment(member, Operation.Read, gear)).toBe(true);
+    });
+  });
+
+  describe('Operation.Update', () => {
+    it('should always be false', () => {
+      expect(equipment(member, Operation.Update, gear)).toBe(false);
+    });
+
+    it('should be true for equipment.pending === null', () => {
+      member.permission.name = Permission.Owner;
+      gear.pending = null;
+      expect(equipment(member, Operation.Update, gear)).toBe(true);
+    });
+
+    it('should be false for equipment.pending === object', () => {
+      member.permission.name = Permission.Owner;
+      gear.pending = { team_id: 1, location_id: 1 };
+      expect(equipment(member, Operation.Update, gear)).toBe(false);
+    });
+
+    it('should be true for permission.name === Permission.Owner', () => {
+      member.permission.name = Permission.Owner;
+      expect(equipment(member, Operation.Update)).toBe(true);
+    });
+
+    it('should be true for permission.name === Permission.Editor', () => {
+      member.permission.name = Permission.Editor;
+      expect(equipment(member, Operation.Update)).toBe(true);
+    });
+
+    it('should be true for permission.gear === true', () => {
+      member.permission.gear = true;
+      expect(equipment(member, Operation.Update)).toBe(true);
+    });
+  });
+
+  describe('Operation.Destroy', () => {
+    it('should always be false', () => {
+      member.permission.name = Permission.Editor;
+      expect(equipment(null, Operation.Destroy)).toBe(false);
+      expect(equipment(member, Operation.Destroy, null)).toBe(false);
+      expect(equipment(member, Operation.Destroy, gear)).toBe(false);
+    });
+  });
+});

--- a/src/spec/permissions/inspection.permissions.spec.ts
+++ b/src/spec/permissions/inspection.permissions.spec.ts
@@ -45,7 +45,6 @@ describe('Inspection Permissions', () => {
       expect(inspections(member)).toBe(true);
       expect(inspections(member, Operation.Read, null)).toBe(true);
       expect(inspections(member, Operation.Read, inspection)).toBe(true);
-      expect(inspections(member, Operation.Read, inspection)).toBe(true);
     });
   });
 
@@ -54,32 +53,32 @@ describe('Inspection Permissions', () => {
       expect(inspections(member, Operation.Update, inspection)).toBe(false);
     });
 
-    it('should be false without a inspection', () => {
-      member.permission.name = Permission.Editor;
-      expect(inspections(member, Operation.Update, null)).toBe(false);
-    });
-
     it('should be true for permission.name === Permission.Owner', () => {
       member.permission.name = Permission.Owner;
-      expect(inspections(member, Operation.Update, inspection)).toBe(true);
+      expect(inspections(member, Operation.Update)).toBe(true);
     });
 
     it('should be true for permission.name === Permission.Editor', () => {
       member.permission.name = Permission.Editor;
-      expect(inspections(member, Operation.Update, inspection)).toBe(true);
+      expect(inspections(member, Operation.Update)).toBe(true);
     });
 
     it('should be true for permission.gear === true', () => {
       member.permission.gear = true;
-      expect(inspections(member, Operation.Update, inspection)).toBe(true);
+      expect(inspections(member, Operation.Update)).toBe(true);
     });
 
     it('should be true for permission.gear_basic === true', () => {
       member.permission.gear_basic = true;
-      expect(inspections(member, Operation.Update, inspection)).toBe(true);
+      expect(inspections(member, Operation.Update)).toBe(true);
     });
 
-    it('should be true for inspection.member_id === member.id', () => {
+    it('should be false for repair.member_id === member.id without a repair', () => {
+      inspection.member_id = member.id;
+      expect(inspections(member, Operation.Update)).toBe(false);
+    });
+
+    it('should be true for inspection.member_id === member.id with a repair', () => {
       inspection.member_id = member.id;
       expect(inspections(member, Operation.Update, inspection)).toBe(true);
     });

--- a/src/spec/permissions/repair.permissions.spec.ts
+++ b/src/spec/permissions/repair.permissions.spec.ts
@@ -36,7 +36,6 @@ describe('Repair Permissions', () => {
       expect(repairs(member)).toBe(true);
       expect(repairs(member, Operation.Read, null)).toBe(true);
       expect(repairs(member, Operation.Read, repair)).toBe(true);
-      expect(repairs(member, Operation.Read, repair)).toBe(true);
     });
   });
 
@@ -71,37 +70,42 @@ describe('Repair Permissions', () => {
       expect(repairs(member, Operation.Update, repair)).toBe(false);
     });
 
-    it('should be false without a repair', () => {
-      member.permission.name = Permission.Editor;
-      expect(repairs(member, Operation.Update, null)).toBe(false);
-    });
-
     it('should be true for permission.name === Permission.Owner', () => {
       member.permission.name = Permission.Owner;
-      expect(repairs(member, Operation.Update, repair)).toBe(true);
+      expect(repairs(member, Operation.Update)).toBe(true);
     });
 
     it('should be true for permission.name === Permission.Editor', () => {
       member.permission.name = Permission.Editor;
-      expect(repairs(member, Operation.Update, repair)).toBe(true);
+      expect(repairs(member, Operation.Update)).toBe(true);
     });
 
     it('should be true for permission.gear === true', () => {
       member.permission.gear = true;
-      expect(repairs(member, Operation.Update, repair)).toBe(true);
+      expect(repairs(member, Operation.Update)).toBe(true);
     });
 
     it('should be true for permission.gear_basic === true', () => {
       member.permission.gear_basic = true;
-      expect(repairs(member, Operation.Update, repair)).toBe(true);
+      expect(repairs(member, Operation.Update)).toBe(true);
     });
 
-    it('should be true for repair.added_by.id === member.id', () => {
+    it('should be false for repair.added_by.id === member.id without a repair', () => {
+      repair.added_by.id = member.id;
+      expect(repairs(member, Operation.Update)).toBe(false);
+    });
+
+    it('should be true for repair.added_by.id === member.id with a repair', () => {
       repair.added_by.id = member.id;
       expect(repairs(member, Operation.Update, repair)).toBe(true);
     });
 
-    it('should be true for repair.assigned_to.id === member.id', () => {
+    it('should be false for repair.assigned_to.id === member.id without a repair', () => {
+      repair.assigned_to.id = member.id;
+      expect(repairs(member, Operation.Update)).toBe(false);
+    });
+
+    it('should be true for repair.assigned_to.id === member.id with a repair', () => {
       repair.assigned_to.id = member.id;
       expect(repairs(member, Operation.Update, repair)).toBe(true);
     });

--- a/src/spec/tools/can.tool.spec.ts
+++ b/src/spec/tools/can.tool.spec.ts
@@ -121,7 +121,12 @@ describe('Can', () => {
       expect(typeof can.update).toBe('function');
     });
 
-    it('should call can.action with given arguments', () => {
+    it('should call can.action without a record', () => {
+      can.update(member, 'repairs');
+      expect(can.action).toHaveBeenCalledWith(member, 'repairs', Operation.Update, undefined);
+    });
+
+    it('should call can.action with a record', () => {
       can.update(member, 'repairs', record);
       expect(can.action).toHaveBeenCalledWith(member, 'repairs', Operation.Update, record);
     });
@@ -136,7 +141,12 @@ describe('Can', () => {
       expect(typeof can.destroy).toBe('function');
     });
 
-    it('should call can.action with given arguments', () => {
+    it('should call can.action without a record', () => {
+      can.destroy(member, 'repairs');
+      expect(can.action).toHaveBeenCalledWith(member, 'repairs', Operation.Destroy, undefined);
+    });
+
+    it('should call can.action with a record', () => {
       can.destroy(member, 'repairs', record);
       expect(can.action).toHaveBeenCalledWith(member, 'repairs', Operation.Destroy, record);
     });

--- a/src/spec/tools/factory.tool.spec.ts
+++ b/src/spec/tools/factory.tool.spec.ts
@@ -83,6 +83,7 @@ describe('Factory', () => {
         'Brand',
         'Category',
         'Config',
+        'CurrencyCost',
         'CustomField',
         'Duty',
         'EmergencyContact',
@@ -105,6 +106,7 @@ describe('Factory', () => {
         'Result',
         'Role',
         'StatusLabel',
+        'SymbolCost',
         'Team',
         'Username'
       ];


### PR DESCRIPTION
- Add equipment to supported client permissions.
- Create better interfaces for cost on Equipment and Role, versus cost on Repair (they have different attributes for currency).
- Create costing factories and remove previous inline factories.
- In existing permissions, only fallback on requiring an item for update permission checks, when that item might be required, e.g. with for a repair's owner.